### PR TITLE
MNT: Replace master with main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Sphinx extension for collecting examples from narrative documentation
 #####################################################################
 
-Your `Sphinx <https://www.sphinx-doc.org/en/master/>`__ documentation pages contain a lot of information: overviews, examples, how-tos, and references.
+Your `Sphinx <https://www.sphinx-doc.org/en/main/>`__ documentation pages contain a lot of information: overviews, examples, how-tos, and references.
 Embedded within your documentation pages might be useful standalone content.
 This content makes sense in the flow of your existing documentation, but it might also get lost.
 The ``sphinx-example-index`` extension helps you to resurface content into easily-discovered standalone pages.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ pkg_metadata = importlib_metadata.metadata('sphinx-example-index')
 rst_epilog = """
 
 .. _Astropy: https://www.astropy.org
-.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _Sphinx: https://www.sphinx-doc.org/en/main/
 .. _tox: https://tox.readthedocs.io/en/latest/
 .. _flake8: https://flake8.pycqa.org/en/latest/
 """
@@ -48,8 +48,8 @@ needs_sphinx = '1.7'
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build', '_templates']
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents. Set to the "smart" one.


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.